### PR TITLE
refactor: use `esbuild-plugins-node-modules-polyfill`

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,14 +155,13 @@ Check the `build-server.mjs` function and make sure you're defining each environ
 
 Other node packages that Remix uses must be polyfilled to work on Cloudflare.
 
-If you get an error that says something like `Could not resolve "https" (use "platform: 'node'" when building for node)`, make sure you're importing the `@esbuild-plugins/node-modules-polyfill` plugin in your `build-server.mjs`
+If you get an error that says something like `Could not resolve "https" (use "platform: 'node'" when building for node)`, make sure you're importing the `esbuild-plugins-node-modules-polyfill` plugin in your `build-server.mjs`
 
 ```js
-import NodeModulesPolyfill from "@esbuild-plugins/node-modules-polyfill"
-const { NodeModulesPolyfillPlugin } = NodeModulesPolyfill
+import { nodeModulesPolyfillPlugin } from "esbuild-plugins-node-modules-polyfill"
 
 esbuild.build({
-  plugins: [NodeModulesPolyfillPlugin()],
+  plugins: [nodeModulesPolyfillPlugin()],
 })
 ```
 

--- a/build-server.mjs
+++ b/build-server.mjs
@@ -1,7 +1,6 @@
 import esbuild from "esbuild"
 
-import NodeModulesPolyfill from "@esbuild-plugins/node-modules-polyfill"
-const { NodeModulesPolyfillPlugin } = NodeModulesPolyfill
+import { nodeModulesPolyfillPlugin } from "esbuild-plugins-node-modules-polyfill"
 
 import alias from "esbuild-plugin-alias"
 
@@ -60,7 +59,7 @@ async function build() {
     },
     outfile,
     plugins: [
-      NodeModulesPolyfillPlugin(),
+      nodeModulesPolyfillPlugin(),
       alias({
         "@prisma/client": require.resolve("@prisma/client"),
       }),

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "update:typescript-eslint": "npm i --save-dev @typescript-eslint/eslint-plugin @typescript-eslint/parser"
   },
   "dependencies": {
-    "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
     "@prisma/client": "^3.7.0",
     "@prisma/generator-helper": "^3.7.0",
     "@remix-run/cloudflare-pages": "^1.1.1",
@@ -28,6 +27,7 @@
     "@tailwindcss/forms": "^0.4.0",
     "cross-env": "^7.0.3",
     "esbuild": "^0.14.10",
+    "esbuild-plugins-node-modules-polyfill": "^1.5.0",
     "esbuild-plugin-alias": "^0.2.1",
     "esbuild-register": "^3.3.1",
     "mongo-uri-builder": "^4.0.0",


### PR DESCRIPTION
This PR replaces `@esbuild-plugins/node-modules-polyfill` with the up-to-date & maintained `esbuild-plugins-node-modules-polyfill`

The `esbuild-plugins` repo itself points towards using `esbuild-plugin-polyfill-node` instead
https://github.com/remorses/esbuild-plugins/blob/373b44902ad3e669f7359c857de09a930ce1ce90/README.md?plain=1#L15-L16

After doing this in the Remix repo (see https://github.com/remix-run/remix/pull/5274), we got quite some new bugs, so we chose to go for @imranbarbhuiya's  `esbuild-plugins-node-modules-polyfill` instead (see https://github.com/remix-run/remix/pull/6562), which is an up-to-date and well maintained alternative

Added benefit is that we won't get the following deprecation warnings when installing `@esbuild-plugins/node-modules-polyfill`:

```sh
npm WARN deprecated rollup-plugin-inject@3.0.2: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.
npm WARN deprecated sourcemap-codec@1.4.8: Please use @jridgewell/sourcemap-codec instead
```